### PR TITLE
Fixed issue where centered tour steps were appearing blurry

### DIFF
--- a/projects/common/src/lib/controls/guided-tour/guided-tour.component.html
+++ b/projects/common/src/lib/controls/guided-tour/guided-tour.component.html
@@ -23,8 +23,8 @@
   <div #tourStep *ngIf="currentTourStep"
     class="tour-step tour-{{ KebabCase(currentTourStep.Orientation) }}"
     [ngClass]="{'page-tour-step': !currentTourStep.Selector, 'step-error': IsStepError}"
-    [style.top.px]="(currentTourStep.Selector && selectedElementRect ? topPosition : null)"
-    [style.left.px]="(currentTourStep.Selector && selectedElementRect ? leftPosition : null)"
+    [style.top.px]="(currentTourStep.Selector && selectedElementRect ? topPosition : centerTopPosition)"
+    [style.left.px]="(currentTourStep.Selector && selectedElementRect ? leftPosition : centerLeftPosition)"
     [style.width.px]="(currentTourStep.Selector && selectedElementRect ? calculatedTourStepWidth : null)"
     [style.transform]="(currentTourStep.Selector && selectedElementRect ? transform : null)">
     <div *ngIf="currentTourStep.Selector" class="tour-arrow"></div>

--- a/projects/common/src/lib/controls/guided-tour/guided-tour.component.scss
+++ b/projects/common/src/lib/controls/guided-tour/guided-tour.component.scss
@@ -57,10 +57,9 @@ lcu-guided-tour {
 
     &.page-tour-step {
       max-width: 425px;
+      min-height: 200px;
+      min-width: 375px;
       width: 50%;
-      left: 50%;
-      top: 50%;
-      transform: translate(-50%, -50%);
     }
 
     &.tour-bottom,

--- a/projects/common/src/lib/controls/guided-tour/guided-tour.component.ts
+++ b/projects/common/src/lib/controls/guided-tour/guided-tour.component.ts
@@ -425,6 +425,22 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
         return 0;
     }
 
+    public get centerTopPosition(): number {
+      if (!this.tourStepWidth) {
+          return null;
+      }
+      const rect = this.dom.querySelector('body').getBoundingClientRect();
+      return (rect.height / 2) - (this.tourStepWidth / 2);
+    }
+
+    public get centerLeftPosition(): number {
+      if (!this.tourStepWidth) {
+          return null;
+      }
+      const rect = this.dom.querySelector('body').getBoundingClientRect();
+      return (rect.width / 2) - (this.tourStepWidth / 2);
+    }
+
     protected getHighlightPadding(): number {
         let paddingAdjustment = this.currentTourStep.UseHighlightPadding ? this.highlightPadding : 0;
         if (this.currentTourStep.HighlightPadding) {


### PR DESCRIPTION
Fixed issue where centered tour steps were appearing blurry. Caused by a CSS bug in Chrome that occurs when you use the `transform: translate(-50%, -50%);` style.